### PR TITLE
fix: fix issue rendering full width on mobile

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,8 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
-import "../styles/vendor/nucleo/css/nucleo.css";
-import "../styles/vendor/font-awesome/css/font-awesome.min.css";
 import "../styles/argon-design-system-react.css";
+import "../styles/styles.css";
+import "../styles/vendor/font-awesome/css/font-awesome.min.css";
+import "../styles/vendor/nucleo/css/nucleo.css";
 
 function MyApp({ Component, pageProps }) {
 	return <Component {...pageProps} />;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,0 +1,3 @@
+body>div:first-child {
+    overflow-x: hidden;
+}


### PR DESCRIPTION
On mobile devices, the layout wasn't rendering the full width. The fix seems to be to set the scaling factor of the viewport to a constant value of 1. Here's the before and after:

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/2646053/148787450-2a6733e4-0bc7-45cb-9832-1891b356d068.png">
