### PR TITLE
fix: fix render error in ExperienceCard

### DIFF
--- a/components/ExperienceCard.jsx
+++ b/components/ExperienceCard.jsx
@@ -44,7 +44,7 @@ const ExperienceCard = ({ data }) => {
 						</div>
 						<CardTitle tag="h5">{data.role}</CardTitle>
 						<CardSubtitle>{data.date}</CardSubtitle>
-						<CardText className="description my-3 text-left">
+						<CardText tag="div" className="description my-3 text-left">
 							{data.desc}
 							<ul>
 								{data.descBullets


### PR DESCRIPTION
By default, `<CardText>` renders as a `<p>` tag which yields an error that `<ul>` tags cannot be nested under `<p>` tags. This change instructs `<CardText>` to render as a `<div>` tag instead.